### PR TITLE
feat: add support for force exit

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -73,6 +73,7 @@ function parseOptions() {
       case '--test-force-exit':
       case '--forceExit':
         options.forceExit = true
+        break
       default:
         throw new Error(`Unknown option: ${option}`)
     }
@@ -114,8 +115,8 @@ if (options.writeSnapshots) {
   args.push('--test-update-snapshots')
 }
 
-if(options.forceExit){
-  assert(major === 20 && minor > 13 || major >= 22, 'For forceExit, use Node.js >= 20.14.0')
+if (options.forceExit) {
+  assert((major === 20 && minor > 13) || major >= 22, 'For forceExit, use Node.js >= 20.14.0')
   args.push('--test-force-exit')
 }
 


### PR DESCRIPTION
This adds support for the `--test-force-exit` flag (known as `--forceExit` in jest) which exits after all tests finished even if some handles are still open. I needed this for https://github.com/ExodusMovement/passkeys-mpc/pull/309 as the tests were hanging in the CI after completion. 