### PR TITLE
feat: enable coverage through `EXODUS_TEST_COVERAGE`

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -14,7 +14,6 @@ import assert from 'node:assert/strict'
 import { Queue } from '@chalker/queue'
 import glob from 'fast-glob'
 import { haveModuleMocks, haveSnapshots, haveForceExit } from '../src/version.js'
-import { isTruthy } from '../src/env.js'
 
 const bindir = dirname(fileURLToPath(import.meta.url))
 const DEFAULT_PATTERNS = [`**/?(*.)+(spec|test).?([cm])[jt]s?(x)`] // do not trust magic dirs by default
@@ -49,7 +48,7 @@ function parseOptions() {
     flow: false,
     esbuild: false,
     babel: false,
-    coverage: isTruthy(process.env.EXODUS_TEST_COVERAGE),
+    coverage: getEnvFlag('EXODUS_TEST_COVERAGE'),
     coverageEngine: 'c8', // c8 or node
     watch: false,
     only: false,

--- a/bin/index.js
+++ b/bin/index.js
@@ -14,6 +14,7 @@ import assert from 'node:assert/strict'
 import { Queue } from '@chalker/queue'
 import glob from 'fast-glob'
 import { haveModuleMocks, haveSnapshots, haveForceExit } from '../src/version.js'
+import { isTruthy } from '../src/env.js'
 
 const bindir = dirname(fileURLToPath(import.meta.url))
 const DEFAULT_PATTERNS = [`**/?(*.)+(spec|test).?([cm])[jt]s?(x)`] // do not trust magic dirs by default
@@ -48,7 +49,7 @@ function parseOptions() {
     flow: false,
     esbuild: false,
     babel: false,
-    coverage: false,
+    coverage: isTruthy(process.env.EXODUS_TEST_COVERAGE),
     coverageEngine: 'c8', // c8 or node
     watch: false,
     only: false,

--- a/src/env.js
+++ b/src/env.js
@@ -1,5 +1,0 @@
-const truthy = new Set(['true', '1', 'yes', 'y', 'on'])
-
-export function isTruthy(envVar) {
-  return truthy.has(envVar)
-}

--- a/src/env.js
+++ b/src/env.js
@@ -1,0 +1,5 @@
+const truthy = new Set(['true', '1', 'yes', 'y', 'on'])
+
+export function isTruthy(envVar) {
+  return truthy.has(envVar)
+}


### PR DESCRIPTION
I would like to re-enable coverage collection in hydra in the CI. We run the test scripts through the root, which delegates to the package test script. We have some test scripts that look like this: `yarn run -T exodus-test --jest && yarn test:types`. Just appending the `--coverage` parameter wouldn't be enough in that case. Of course we could re-arrange order, but using an env var is more robust. 