### PR TITLE
fix: forward timeout in `.each()`

### DIFF
--- a/src/jest.js
+++ b/src/jest.js
@@ -51,7 +51,7 @@ const eachCallerLocation = []
 const makeEach =
   (impl) =>
   (list, ...rest) =>
-  (template, fn, timeout) => {
+  (template, fn, ...restArgs) => {
     eachCallerLocation.unshift(getCallerLocation())
     // Hack for common testing with simple arrow functions, until we can disable esbuild minification
     const formatArg = (x) => (x && x instanceof Function && `${x}` === '()=>{}' ? '() => {}' : x)
@@ -86,7 +86,7 @@ const makeEach =
         if (length > 0) name = utilFormat(name, ...args.slice(0, length).map(formatArg))
       }
 
-      impl(name, () => (Array.isArray(args) ? fn(...args) : fn(args)), timeout)
+      impl(name, () => (Array.isArray(args) ? fn(...args) : fn(args)), ...restArgs)
     }
 
     eachCallerLocation.shift()

--- a/src/jest.js
+++ b/src/jest.js
@@ -51,7 +51,7 @@ const eachCallerLocation = []
 const makeEach =
   (impl) =>
   (list, ...rest) =>
-  (template, fn) => {
+  (template, fn, timeout) => {
     eachCallerLocation.unshift(getCallerLocation())
     // Hack for common testing with simple arrow functions, until we can disable esbuild minification
     const formatArg = (x) => (x && x instanceof Function && `${x}` === '()=>{}' ? '() => {}' : x)
@@ -86,7 +86,7 @@ const makeEach =
         if (length > 0) name = utilFormat(name, ...args.slice(0, length).map(formatArg))
       }
 
-      impl(name, () => (Array.isArray(args) ? fn(...args) : fn(args)))
+      impl(name, () => (Array.isArray(args) ? fn(...args) : fn(args)), timeout)
     }
 
     eachCallerLocation.shift()


### PR DESCRIPTION
timeout was previously not honored in cases like below:

```js
test.each([1,2,3])('case %s', (number) => {}, 10_000)
```