### PR TITLE
fix: make `callCount` a function instead of getter

### DIFF
--- a/src/engine.pure.cjs
+++ b/src/engine.pure.cjs
@@ -357,7 +357,7 @@ const mock = {
     let impl = implementation
     const _mock = {
       calls: [],
-      get callCount() {
+      callCount() {
         return this.calls.length
       },
       mockImplementation: (fn) => {


### PR DESCRIPTION
I ran into this when doing some testing on hermes and noticed that it behaves differently than the native node implementation. `callCount` should be [a function](https://nodejs.org/api/test.html#ctxcallcount), not a getter.