### PR TITLE
chore: add Jan, Mark as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @ChALkeR @sparten11740
+* @ChALkeR @sparten11740 @mvayngrib
 
 /.github/ @ChALkeR @633kh4ck @mvayngrib

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @ChALkeR
+* @ChALkeR @sparten11740
 
 /.github/ @ChALkeR @633kh4ck @mvayngrib


### PR DESCRIPTION
i want to unblock PRs like:
https://github.com/ExodusMovement/test/pull/20
https://github.com/ExodusMovement/test/pull/19
https://github.com/ExodusMovement/test/pull/16

they've all been open for a while with no engagement from the current codeowners 😉 