### PR TITLE
fix: support jest snapshot matchers with snapshot name

### DIFF
--- a/src/jest.snapshot.js
+++ b/src/jest.snapshot.js
@@ -130,7 +130,8 @@ const snapOnDisk = (expect, orig, matcherOrSnapshotName, snapshotName) => {
 
   if (!context?.assert?.snapshot) {
     const namePath = getTestNamePath(context).map((x) => (x === '<anonymous>' ? '' : x))
-    return matchSnapshot(readSnapshot, getAssert(), namePath.join(' '), serialize(obj))
+    const qualified = name ? [...namePath.slice(0, -1), `${namePath.at(-1)}: ${name}`] : namePath
+    return matchSnapshot(readSnapshot, getAssert(), qualified.join(' '), serialize(obj))
   }
 
   // Node.js always wraps with newlines, while jest wraps only those that are already multiline

--- a/src/jest.snapshot.js
+++ b/src/jest.snapshot.js
@@ -69,7 +69,7 @@ function wrapContextName(fn, snapshotName) {
   try {
     return fn()
   } finally {
-    assert.notEqual(context.fullName, value, 'fullName should be different after test')
+    assert.notEqual(context.fullName, value)
     delete context.fullName
     assert.equal(context.fullName, value)
   }

--- a/tests/jest/__snapshots__/snapshot.test.js.snap
+++ b/tests/jest/__snapshots__/snapshot.test.js.snap
@@ -319,7 +319,7 @@ exports[`simple 9`] = `
 
 exports[`supports named snapshots: not so public knowledge 1`] = `
 {
-  "identity": "Batman",
+  "alterEgo": "Batman",
   "name": "Bruce Wayne",
 }
 `;

--- a/tests/jest/__snapshots__/snapshot.test.js.snap
+++ b/tests/jest/__snapshots__/snapshot.test.js.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`  1`] = `"empty names test"`;
+exports[`  1`] = `
+"empty names test"
+`;
 
 exports[`arrays 1`] = `
 [
@@ -58,7 +58,9 @@ exports[`arrays 5`] = `
 ]
 `;
 
-exports[`async errors 1`] = `"slow but nah"`;
+exports[`async errors 1`] = `
+"slow but nah"
+`;
 
 exports[`complex 1`] = `
 [
@@ -112,7 +114,9 @@ I
 Failed"
 `;
 
-exports[`formateted objects 1`] = `Any<Number>`;
+exports[`formateted objects 1`] = `
+Any<Number>
+`;
 
 exports[`formateted objects 2`] = `
 {
@@ -121,7 +125,23 @@ exports[`formateted objects 2`] = `
 }
 `;
 
-exports[`mixed 1`] = `true`;
+exports[`mixed 1`] = `
+true
+`;
+
+exports[`mixed 10`] = `
+41
+`;
+
+exports[`mixed 11`] = `
+{
+  "bar": "buz",
+}
+`;
+
+exports[`mixed 12`] = `
+{}
+`;
 
 exports[`mixed 2`] = `
 [
@@ -137,11 +157,17 @@ exports[`mixed 3`] = `
 }
 `;
 
-exports[`mixed 4`] = `43`;
+exports[`mixed 4`] = `
+43
+`;
 
-exports[`mixed 5`] = `{}`;
+exports[`mixed 5`] = `
+{}
+`;
 
-exports[`mixed 6`] = `[]`;
+exports[`mixed 6`] = `
+[]
+`;
 
 exports[`mixed 7`] = `
 [
@@ -151,19 +177,13 @@ exports[`mixed 7`] = `
 ]
 `;
 
-exports[`mixed 8`] = `[]`;
-
-exports[`mixed 9`] = `false`;
-
-exports[`mixed 10`] = `41`;
-
-exports[`mixed 11`] = `
-{
-  "bar": "buz",
-}
+exports[`mixed 8`] = `
+[]
 `;
 
-exports[`mixed 12`] = `{}`;
+exports[`mixed 9`] = `
+false
+`;
 
 exports[`nested test nested test one 1`] = `
 {
@@ -233,37 +253,89 @@ exports[`property matchers will check the values and pass 1`] = `
 }
 `;
 
-exports[`simple 1`] = `10`;
+exports[`simple 1`] = `
+10
+`;
 
-exports[`simple 2`] = `null`;
+exports[`simple 10`] = `
+/hello/
+`;
 
-exports[`simple 3`] = `undefined`;
+exports[`simple 11`] = `
+true
+`;
 
-exports[`simple 4`] = `[]`;
+exports[`simple 12`] = `
+NaN
+`;
 
-exports[`simple 5`] = `/xx/`;
+exports[`simple 13`] = `
+{}
+`;
 
-exports[`simple 6`] = `Infinity`;
+exports[`simple 14`] = `
+42
+`;
 
-exports[`simple 7`] = `false`;
+exports[`simple 15`] = `
+[]
+`;
 
-exports[`simple 8`] = `true`;
+exports[`simple 16`] = `
+-Infinity
+`;
 
-exports[`simple 9`] = `{}`;
+exports[`simple 2`] = `
+null
+`;
 
-exports[`simple 10`] = `/hello/`;
+exports[`simple 3`] = `
+undefined
+`;
 
-exports[`simple 11`] = `true`;
+exports[`simple 4`] = `
+[]
+`;
 
-exports[`simple 12`] = `NaN`;
+exports[`simple 5`] = `
+/xx/
+`;
 
-exports[`simple 13`] = `{}`;
+exports[`simple 6`] = `
+Infinity
+`;
 
-exports[`simple 14`] = `42`;
+exports[`simple 7`] = `
+false
+`;
 
-exports[`simple 15`] = `[]`;
+exports[`simple 8`] = `
+true
+`;
 
-exports[`simple 16`] = `-Infinity`;
+exports[`simple 9`] = `
+{}
+`;
+
+exports[`supports named snapshots: not so public knowledge 1`] = `
+{
+  "identity": "Batman",
+  "name": "Bruce Wayne",
+}
+`;
+
+exports[`supports named snapshots: public knowledge 1`] = `
+{
+  "name": "Bruce Wayne",
+}
+`;
+
+exports[`supports named snapshots: public knowledge 2`] = `
+{
+  "address": "Arkham Asylum",
+  "name": "Joker",
+}
+`;
 
 exports[`test A 1`] = `
 {
@@ -330,11 +402,17 @@ exports[`weird  names
 "
 `;
 
-exports[`weird  names  !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_\`abcdefghijklmnopqrstuvwxyz{|}~ 1`] = `" !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_\`abcdefghijklmnopqrstuvwxyz{|}~"`;
+exports[`weird  names  !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_\`abcdefghijklmnopqrstuvwxyz{|}~ 1`] = `
+" !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_\`abcdefghijklmnopqrstuvwxyz{|}~"
+`;
 
-exports[`weird  names $ 1`] = `"$"`;
+exports[`weird  names $ 1`] = `
+"$"
+`;
 
-exports[`weird  names > 1`] = `">"`;
+exports[`weird  names > 1`] = `
+">"
+`;
 
 exports[`weird  names \\
 \`
@@ -344,7 +422,13 @@ exports[`weird  names \\
 \\\`\`"
 `;
 
-exports[`weird  names \\ 1`] = `"\\"`;
+exports[`weird  names \\ 1`] = `
+"\\"
+`;
+
+exports[`weird  names \` 1`] = `
+"\`"
+`;
 
 exports[`weird  names \` \`
  \` 1`] = `
@@ -352,13 +436,19 @@ exports[`weird  names \` \`
  \`"
 `;
 
-exports[`weird  names \` \` \` 1`] = `"\` \` \`"`;
-
-exports[`weird  names \` 1`] = `"\`"`;
-
-exports[`weird  names {} 1`] = `"{}"`;
+exports[`weird  names \` \` \` 1`] = `
+"\` \` \`"
+`;
 
 exports[`weird  names multi
-line 1`] = `0`;
+line 1`] = `
+0
+`;
 
-exports[`weird  names with \` 1`] = `42`;
+exports[`weird  names with \` 1`] = `
+42
+`;
+
+exports[`weird  names {} 1`] = `
+"{}"
+`;

--- a/tests/jest/snapshot.test.js
+++ b/tests/jest/snapshot.test.js
@@ -251,7 +251,7 @@ test('inline snapshots, prefixed', () => {
 
 it('supports named snapshots', async () => {
   expect({ name: 'Bruce Wayne' }).toMatchSnapshot('public knowledge')
-  expect({ identity: 'Batman', name: 'Bruce Wayne' }).toMatchSnapshot('not so public knowledge')
+  expect({ alterEgo: 'Batman', name: 'Bruce Wayne' }).toMatchSnapshot('not so public knowledge')
   expect({ name: 'Joker', address: 'Arkham Asylum' }).toMatchSnapshot('public knowledge')
 
   let createRequire

--- a/tests/jest/snapshot.test.js
+++ b/tests/jest/snapshot.test.js
@@ -1,5 +1,3 @@
-import { createRequire } from 'node:module'
-
 it('simple', () => {
   expect(10).toMatchSnapshot()
   expect(null).toMatchSnapshot()
@@ -251,10 +249,18 @@ test('inline snapshots, prefixed', () => {
           `) // end padding is ignored!
 })
 
-it('supports named snapshots', () => {
+it('supports named snapshots', async () => {
   expect({ name: 'Bruce Wayne' }).toMatchSnapshot('public knowledge')
   expect({ identity: 'Batman', name: 'Bruce Wayne' }).toMatchSnapshot('not so public knowledge')
   expect({ name: 'Joker', address: 'Arkham Asylum' }).toMatchSnapshot('public knowledge')
+
+  let createRequire
+  try {
+    ;({ createRequire } = await import('node:module'))
+  } catch {
+    // skip the rest of this test for environments without node:module
+    return
+  }
 
   const require = createRequire(import.meta.url)
   const snapshots = require('./__snapshots__/snapshot.test.js.snap')

--- a/tests/jest/snapshot.test.js
+++ b/tests/jest/snapshot.test.js
@@ -1,3 +1,5 @@
+import { createRequire } from 'node:module'
+
 it('simple', () => {
   expect(10).toMatchSnapshot()
   expect(null).toMatchSnapshot()
@@ -247,4 +249,21 @@ test('inline snapshots, prefixed', () => {
     ],
   }
           `) // end padding is ignored!
+})
+
+it('supports named snapshots', () => {
+  expect({ name: 'Bruce Wayne' }).toMatchSnapshot('public knowledge')
+  expect({ identity: 'Batman', name: 'Bruce Wayne' }).toMatchSnapshot('not so public knowledge')
+  expect({ name: 'Joker', address: 'Arkham Asylum' }).toMatchSnapshot('public knowledge')
+
+  const require = createRequire(import.meta.url)
+  const snapshots = require('./__snapshots__/snapshot.test.js.snap')
+
+  ;[
+    'supports named snapshots: public knowledge 1',
+    'supports named snapshots: public knowledge 2',
+    'supports named snapshots: not so public knowledge 1',
+  ].forEach((name) => {
+    expect(Object.hasOwn(snapshots, name)).toBe(true)
+  })
 })


### PR DESCRIPTION
Add support for passing a name to jest's snapshot matchers, e.g. `expect(obj).toMatchSnapshot('some snapshot name')`.

Fixes https://github.com/ExodusMovement/test/issues/22