### PR TITLE
feat: add opera:puppeteer engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Use `--engine` (or `EXODUS_TEST_ENGINE=`) to specify one of:
     - `firefox:puppeteer` — Firefox
     - `brave:puppeteer` — Brave
     - `msedge:puppeteer` — Microsoft Edge
+    - `opera:puppeteer` — Opera
 - Barebone engines (system-provided or installed with `npx jsvu`):
   - `d8:bundle` — [v8 CLI](https://v8.dev/docs/d8) (Chrome/Blink/Node.js JavaScript engine)
   - `jsc:bundle` — [JavaScriptCore](https://docs.webkit.org/Deep%20Dive/JSC/JavaScriptCore.html) (Safari/WebKit JavaScript engine)

--- a/bin/browsers.js
+++ b/bin/browsers.js
@@ -9,7 +9,7 @@ import { findBinary } from './find-binary.js'
 let puppeteer
 let playwright
 
-const puppeteerBrowsers = { brave: 'chrome', msedge: 'chrome' }
+const puppeteerBrowsers = { brave: 'chrome', msedge: 'chrome', opera: 'chrome' }
 const playwrightBrowsers = { chrome: 'chromium', msedge: 'chromium' }
 
 const launched = Object.create(null)

--- a/bin/find-binary.js
+++ b/bin/find-binary.js
@@ -76,6 +76,10 @@ function findBinaryOnce(name) {
       addPaths('darwin', '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge')
       addPaths('linux', '/usr/bin/msedge', '/snap/bin/msedge', '/opt/microsoft/msedge/msedge')
       break
+    case 'opera':
+      addPaths('darwin', '/Applications/Opera.app/Contents/MacOS/Opera')
+      addPaths('linux', '/usr/bin/opera', '/snap/bin/opera')
+      break
     case 'safari':
       addPaths('darwin', '/Applications/Safari.app/Contents/MacOS/Safari')
       break

--- a/bin/index.js
+++ b/bin/index.js
@@ -47,6 +47,7 @@ const ENGINES = new Map(
     'firefox:puppeteer': { binary: 'firefox', browsers: 'puppeteer', ...bundleOpts },
     'brave:puppeteer': { binary: 'brave', browsers: 'puppeteer', ...bundleOpts },
     'msedge:puppeteer': { binary: 'msedge', browsers: 'puppeteer', ...bundleOpts },
+    'opera:puppeteer': { binary: 'opera', browsers: 'puppeteer', ...bundleOpts },
     'chromium:playwright': { binary: 'chromium', browsers: 'playwright', ...bundleOpts },
     'firefox:playwright': { binary: 'firefox', browsers: 'playwright', ...bundleOpts },
     'webkit:playwright': { binary: 'webkit', browsers: 'playwright', ...bundleOpts },


### PR DESCRIPTION
Unlike all other Chromium-based, it (1) crashes and (2) fails to terminate cleanly

Not planned, not significant, keeping the PR mostly to document the attempt