### PR TITLE
fix: anchor GitHub annotation path to GITHUB_WORKSPACE

### DIFF
--- a/bin/github.js
+++ b/bin/github.js
@@ -1,0 +1,9 @@
+import { relative, resolve } from 'node:path'
+
+// Path used for the GitHub `::error file=` annotation. GitHub resolves it from the repo root
+// (GITHUB_WORKSPACE), but under lerna/nx the cwd is the package dir, so a cwd-relative path won't
+// map onto the PR diff. Anchor to GITHUB_WORKSPACE in CI so the annotation lands on the right file.
+export const resolveAnnotationFile = (rawFile, { cwd, CI, GITHUB_WORKSPACE }) => {
+  const absolute = resolve(cwd, rawFile)
+  return CI && GITHUB_WORKSPACE ? relative(GITHUB_WORKSPACE, absolute) : relative(cwd, absolute)
+}

--- a/bin/github.js
+++ b/bin/github.js
@@ -1,9 +1,12 @@
-import { relative, resolve } from 'node:path'
+import { relative, resolve, sep } from 'node:path'
 
 // Path used for the GitHub `::error file=` annotation. GitHub resolves it from the repo root
 // (GITHUB_WORKSPACE), but under lerna/nx the cwd is the package dir, so a cwd-relative path won't
 // map onto the PR diff. Anchor to GITHUB_WORKSPACE in CI so the annotation lands on the right file.
+// GitHub matches annotation paths with POSIX separators, so emit forward slashes even on Windows
+// runners (where node:path would otherwise produce backslashes that never match the repo file).
 export const resolveAnnotationFile = (rawFile, { cwd, CI, GITHUB_WORKSPACE }) => {
   const absolute = resolve(cwd, rawFile)
-  return CI && GITHUB_WORKSPACE ? relative(GITHUB_WORKSPACE, absolute) : relative(cwd, absolute)
+  const base = CI && GITHUB_WORKSPACE ? GITHUB_WORKSPACE : cwd
+  return relative(base, absolute).split(sep).join('/')
 }

--- a/bin/reporter.js
+++ b/bin/reporter.js
@@ -4,6 +4,7 @@ import { relative, resolve, normalize } from 'node:path'
 import { spec as SpecReporter } from 'node:test/reporters'
 import { fileURLToPath } from 'node:url'
 import { color, haveColors, dim } from './color.js'
+import { resolveAnnotationFile } from './github.js'
 
 const { CI, GITHUB_WORKSPACE, LERNA_PACKAGE_NAME } = process.env
 
@@ -159,7 +160,12 @@ export default async function nodeTestReporterExodus(source) {
         if (path.length > 0) assert(path.pop() === data.name) // afterAll can generate failures too, with an empty path
         if (!data.todo) failedFiles.add(file)
         if (!notPrintedError(data.details.error)) {
-          const { body, loc } = extractError(data, relative(cwd, data.file || data.name)) // might be different from current file if in subimport
+          const errorFile = resolveAnnotationFile(data.file || data.name, {
+            cwd,
+            CI,
+            GITHUB_WORKSPACE,
+          })
+          const { body, loc } = extractError(data, errorFile) // might be different from current file if in subimport
           if (!data.todo && CI && loc.line != null && loc.col != null) {
             print(`::error ${serializeGitHub(Object.entries(loc))}::${escapeGitHub(body)}`)
           } else if (body) {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "bin/electron.js",
     "bin/electron.preload.cjs",
     "bin/find-binary.js",
+    "bin/github.js",
     "bin/inband.js",
     "bin/reporter.js",
     "loader/babel.cjs",

--- a/tests/github.test.js
+++ b/tests/github.test.js
@@ -1,0 +1,31 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { resolveAnnotationFile } from '../bin/github.js'
+
+// GitHub resolves `::error file=...` annotation paths from the repo root (GITHUB_WORKSPACE).
+// lerna/nx run each package with cwd = the package dir, so a cwd-relative path points at the wrong
+// place and the annotation never lands on the PR diff. In CI the path must be workspace-relative.
+const GITHUB_WORKSPACE = '/home/runner/work/repo/repo'
+const cwd = `${GITHUB_WORKSPACE}/packages/foo` // what lerna/nx hands the reporter
+const absFile = `${cwd}/src/bar.test.js`
+
+test('CI annotation path is repo-root-relative so it lands on the PR diff', () => {
+  const file = resolveAnnotationFile(absFile, { cwd, CI: '1', GITHUB_WORKSPACE })
+  assert.equal(file, 'packages/foo/src/bar.test.js')
+})
+
+test('a relative input is resolved against cwd before anchoring to the workspace', () => {
+  const file = resolveAnnotationFile('src/bar.test.js', { cwd, CI: '1', GITHUB_WORKSPACE })
+  assert.equal(file, 'packages/foo/src/bar.test.js')
+})
+
+test('outside CI the path stays cwd-relative (local runs are unchanged)', () => {
+  assert.equal(
+    resolveAnnotationFile(absFile, { cwd, CI: undefined, GITHUB_WORKSPACE }),
+    'src/bar.test.js'
+  )
+  assert.equal(
+    resolveAnnotationFile(absFile, { cwd, CI: '1', GITHUB_WORKSPACE: undefined }),
+    'src/bar.test.js'
+  )
+})


### PR DESCRIPTION
## Summary

- Test failures now surface as inline PR annotations under lerna/nx. The reporter's `::error file=,line=,col=::` path was computed with `relative(cwd, …)`; since lerna/nx run each package with cwd = the package dir, the path came out package-relative (`bar.test.js`) and GitHub — which resolves annotation paths from the repo root — never mapped it onto the diff.
- In CI, anchor the path to `GITHUB_WORKSPACE` so it's repo-root-relative (`packages/foo/bar.test.js`). Non-CI runs stay cwd-relative. Logic extracted into `resolveAnnotationFile`.

## Test plan
- `tests/reporter.test.js` covers CI and non-CI cases.
- Verified end-to-end: https://github.com/ExodusMovement/actions-playground/pull/743/files#diff-b13f371a692fc060b202114a7c52895c6c90c86fec8b00b2e6d5deaf1b844ef5
- prettier, eslint, `node --test` pass.

deno failure is pre-existing on master